### PR TITLE
Implement 'table default set' command

### DIFF
--- a/CLI/table.c
+++ b/CLI/table.c
@@ -445,7 +445,14 @@ clean_up:
 
 int do_table_default(int argc, char **argv)
 {
-    return do_table_write(argc, argv, TABLE_SET_DEFAULT_ENTRY);
+    if (is_keyword(*argv, "set")) {
+        NEXT_ARG();
+        return do_table_write(argc, argv, TABLE_SET_DEFAULT_ENTRY);
+    } else {
+        if (*argv != NULL)
+            fprintf(stderr, "%s: unknown keyword\n", *argv);
+        return do_table_help(argc, argv);
+    }
 }
 
 int do_table_help(int argc, char **argv)
@@ -457,13 +464,13 @@ int do_table_help(int argc, char **argv)
             "       %1$s table add pipe ID TABLE ref key MATCH_KEY data ACTION_REFS [priority PRIORITY]\n"
             "       %1$s table update pipe ID TABLE ACTION key MATCH_KEY [data ACTION_PARAMS] [priority PRIORITY]\n"
             "       %1$s table delete pipe ID TABLE [key MATCH_KEY]\n"
-            "       %1$s table default pipe ID TABLE ACTION [data ACTION_PARAMS]\n"
+            "       %1$s table default set pipe ID TABLE ACTION [data ACTION_PARAMS]\n"
             /* Support for this one might be preserved, but makes no sense, because indirect tables
              * has no default entry. In other words we do not forbid this syntax explicitly.
              * "       %1$s table default pipe ID TABLE ref data ACTION_REFS\n" */
             "Unimplemented commands:\n"
             "       %1$s table get pipe ID TABLE [key MATCH_KEY]\n"
-            "       %1$s table default pipe ID TABLE\n"
+            "       %1$s table default get pipe ID TABLE\n"
             "\n"
             "       TABLE := { id TABLE_ID | name FILE | TABLE_FILE }\n"
             "       ACTION := { id ACTION_ID | ACTION_NAME }\n"

--- a/CLI/table.c
+++ b/CLI/table.c
@@ -59,7 +59,7 @@ static int parse_dst_table(int *argc, char ***argv, psabpf_context_t *psabpf_ctx
 }
 
 static int parse_table_action(int *argc, char ***argv, psabpf_table_entry_ctx_t *ctx,
-                              psabpf_action_t *action, bool *indirect_table)
+                              psabpf_action_t *action, bool *indirect_table, bool can_be_last)
 {
     *indirect_table = false;
 
@@ -78,7 +78,10 @@ static int parse_table_action(int *argc, char ***argv, psabpf_table_entry_ctx_t 
         fprintf(stderr, "specify an action by name is not supported yet\n");
         return ENOTSUP;
     }
-    NEXT_ARGP_RET();
+    if (can_be_last)
+        NEXT_ARGP();
+    else
+        NEXT_ARGP_RET();
 
     return NO_ERROR;
 }
@@ -310,7 +313,8 @@ static int parse_entry_priority(int *argc, char ***argv, psabpf_table_entry_t *e
 
 enum table_write_type_t {
     TABLE_ADD_NEW_ENTRY,
-    TABLE_UPDATE_EXISTING_ENTRY
+    TABLE_UPDATE_EXISTING_ENTRY,
+    TABLE_SET_DEFAULT_ENTRY
 };
 
 int do_table_write(int argc, char **argv, enum table_write_type_t write_type)
@@ -342,20 +346,25 @@ int do_table_write(int argc, char **argv, enum table_write_type_t write_type)
         goto clean_up;
 
     /* 2. Get action */
-    if (parse_table_action(&argc, &argv, &ctx, &action, &table_is_indirect) != NO_ERROR)
+    bool can_ba_last_arg = write_type == TABLE_SET_DEFAULT_ENTRY ? true : false;
+    if (parse_table_action(&argc, &argv, &ctx, &action, &table_is_indirect, can_ba_last_arg) != NO_ERROR)
         goto clean_up;
 
-    /* 3. Get key */
-    if (parse_table_key(&argc, &argv, &entry) != NO_ERROR)
-        goto clean_up;
+    /* 3. Get key - default entry has no key */
+    if (write_type != TABLE_SET_DEFAULT_ENTRY) {
+        if (parse_table_key(&argc, &argv, &entry) != NO_ERROR)
+            goto clean_up;
+    }
 
     /* 4. Get action parameters */
     if (parse_action_data(&argc, &argv, &ctx, &entry, &action, table_is_indirect) != NO_ERROR)
         goto clean_up;
 
-    /* 5. Get entry priority */
-    if (parse_entry_priority(&argc, &argv, &entry) != NO_ERROR)
-        goto clean_up;
+    /* 5. Get entry priority - not applicable to default entry */
+    if (write_type != TABLE_SET_DEFAULT_ENTRY) {
+        if (parse_entry_priority(&argc, &argv, &entry) != NO_ERROR)
+            goto clean_up;
+    }
 
     if (argc > 0) {
         fprintf(stderr, "%s: unused argument\n", *argv);
@@ -368,6 +377,8 @@ int do_table_write(int argc, char **argv, enum table_write_type_t write_type)
         error_code = psabpf_table_entry_add(&ctx, &entry);
     else if (write_type == TABLE_UPDATE_EXISTING_ENTRY)
         error_code = psabpf_table_entry_update(&ctx, &entry);
+    else if (write_type == TABLE_SET_DEFAULT_ENTRY)
+        error_code = psabpf_table_entry_set_default_entry(&ctx, &entry);
 
 clean_up:
     psabpf_action_free(&action);
@@ -432,6 +443,11 @@ clean_up:
     return error_code;
 }
 
+int do_table_default(int argc, char **argv)
+{
+    return do_table_write(argc, argv, TABLE_SET_DEFAULT_ENTRY);
+}
+
 int do_table_help(int argc, char **argv)
 {
     (void) argc; (void) argv;
@@ -441,9 +457,12 @@ int do_table_help(int argc, char **argv)
             "       %1$s table add pipe ID TABLE ref key MATCH_KEY data ACTION_REFS [priority PRIORITY]\n"
             "       %1$s table update pipe ID TABLE ACTION key MATCH_KEY [data ACTION_PARAMS] [priority PRIORITY]\n"
             "       %1$s table delete pipe ID TABLE [key MATCH_KEY]\n"
+            "       %1$s table default pipe ID TABLE ACTION [data ACTION_PARAMS]\n"
+            /* Support for this one might be preserved, but makes no sense, because indirect tables
+             * has no default entry. In other words we do not forbid this syntax explicitly.
+             * "       %1$s table default pipe ID TABLE ref data ACTION_REFS\n" */
             "Unimplemented commands:\n"
             "       %1$s table get pipe ID TABLE [key MATCH_KEY]\n"
-            "       %1$s table default pipe ID TABLE set ACTION [data ACTION_PARAMS]\n"
             "       %1$s table default pipe ID TABLE\n"
             "\n"
             "       TABLE := { id TABLE_ID | name FILE | TABLE_FILE }\n"

--- a/CLI/table.h
+++ b/CLI/table.h
@@ -23,13 +23,15 @@
 int do_table_add(int argc, char **argv);
 int do_table_update(int argc, char **argv);
 int do_table_delete(int argc, char **argv);
+int do_table_default(int argc, char **argv);
 int do_table_help(int argc, char **argv);
 
 static const struct cmd table_cmds[] = {
-        {"help",   do_table_help},
-        {"add",    do_table_add},
-        {"update", do_table_update},
-        {"delete", do_table_delete},
+        {"help",    do_table_help},
+        {"add",     do_table_add},
+        {"update",  do_table_update},
+        {"delete",  do_table_delete},
+        {"default", do_table_default},
         {0}
 };
 

--- a/include/psabpf.h
+++ b/include/psabpf.h
@@ -304,6 +304,7 @@ typedef struct psabpf_direct_meter_context {
  */
 typedef struct psabpf_table_entry_context {
     psabpf_bpf_map_descriptor_t table;
+    psabpf_bpf_map_descriptor_t default_entry;
     bool is_indirect;
     bool is_ternary;
 
@@ -376,32 +377,8 @@ int psabpf_table_entry_del(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *
 int psabpf_table_entry_get(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t **entry);
 int psabpf_table_entry_getnext(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t **entry);
 
-/**
- * Sets a default entry.
- *
- * Example code:
- *  psabpf_table_entry_t entry;
- *  if (!psabpf_table_entry_init(&entry))
- *      return;
- *  psabpf_table_entry_tblname(&entry, "xyz");
- *
- *  psabpf_action_t action;
- *  psabpf_action_init(&action);
- *  psabpf_action_setid(&action, 1);
- *  for (action params)
- *      psabpf_action_param_set(&action, "dsada", 12);
- *
- *  if (!psabpf_table_entry_setdefault(&entry))
- *      psabpf_table_entry_free(&entry);
- *      return EINVAL;
- *
- *  psabpf_table_entry_free(&entry);
- *
- * @param entry
- * @return
- */
-int psabpf_table_entry_setdefault(psabpf_table_entry_t *entry);
-int psabpf_table_entry_getdefault(psabpf_table_entry_t *entry);
+int psabpf_table_entry_set_default_entry(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry);
+int psabpf_table_entry_get_default_entry(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry);
 
 /* DirectCounter */
 void psabpf_direct_counter_ctx_init(psabpf_direct_counter_context_t *dc_ctx);

--- a/lib/psabpf_table.c
+++ b/lib/psabpf_table.c
@@ -1869,7 +1869,8 @@ clean_up:
 
 int psabpf_table_entry_set_default_entry(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry)
 {
-    uint64_t key = 0;
+    /* For default entry array map is used, it always has key 32-bit width and its value is assumed to be 0. */
+    const uint32_t key = 0;
     char *value_buffer = NULL;
     int return_code = NO_ERROR;
 
@@ -1880,7 +1881,7 @@ int psabpf_table_entry_set_default_entry(psabpf_table_entry_ctx_t *ctx, psabpf_t
         fprintf(stderr, "can't add default entry: table not opened or table has no default entry\n");
         return EBADF;
     }
-    if (ctx->default_entry.key_size == 0 || ctx->default_entry.key_size > sizeof(key) ||
+    if (ctx->default_entry.key_size != sizeof(key) ||
         ctx->default_entry.value_size == 0 || ctx->default_entry.value_size != ctx->table.value_size) {
         fprintf(stderr, "key size or value is not supported\n");
         return ENOTSUP;

--- a/lib/psabpf_table.c
+++ b/lib/psabpf_table.c
@@ -39,6 +39,7 @@ void psabpf_table_entry_ctx_init(psabpf_table_entry_ctx_t *ctx)
 
     /* 0 is a valid file descriptor */
     ctx->table.fd = -1;
+    ctx->default_entry.fd = -1;
     ctx->btf_metadata.associated_prog = -1;
     ctx->prefixes.fd = -1;
     ctx->tuple_map.fd = -1;
@@ -53,6 +54,7 @@ void psabpf_table_entry_ctx_free(psabpf_table_entry_ctx_t *ctx)
     free_btf(&ctx->btf_metadata);
 
     close_object_fd(&(ctx->table.fd));
+    close_object_fd(&(ctx->default_entry.fd));
     close_object_fd(&(ctx->prefixes.fd));
     close_object_fd(&(ctx->tuple_map.fd));
     close_object_fd(&(ctx->cache.fd));
@@ -280,12 +282,20 @@ int psabpf_table_entry_ctx_tblname(psabpf_context_t *psabpf_ctx, psabpf_table_en
         return ret;
     }
 
-    /* open cache table, this is optional feature for table */
-    char cache_name[256];
-    snprintf(cache_name, sizeof(cache_name), "%s_cache", name);
-    ret = open_bpf_map(psabpf_ctx, cache_name, &ctx->btf_metadata, &ctx->cache);
-    if (ret != NO_ERROR)
-        fprintf(stderr, "warning: cache for table %s not found: %s\n", name, strerror(ret));
+    /* TODO: detect if value type contains "u" union and then threat table as direct;
+     *       in other case as an indirect table (e.g. ActionProfile or ActionSelector).
+     *       This may require changes in API */
+
+    /* Open map with default entry, ignore error(s), because map is optional */
+    char map_name[256];
+    snprintf(map_name, sizeof(map_name), "%s_defaultAction", name);
+    open_bpf_map(psabpf_ctx, map_name, &ctx->btf_metadata, &ctx->default_entry);
+
+    /* open cache table, this is optional feature for table*/
+    snprintf(map_name, sizeof(map_name), "%s_cache", name);
+    ret = open_bpf_map(psabpf_ctx, map_name, &ctx->btf_metadata, &ctx->cache);
+    if (ret == NO_ERROR)
+        fprintf(stderr, "found cache for table: %s\n", name);
 
     ret = init_direct_objects(ctx);
     if (ret != NO_ERROR) {
@@ -1151,7 +1161,7 @@ static int construct_buffer(char * buffer, size_t buffer_len,
     return return_code;
 }
 
-static int handle_direct_counter_write(const char *key, char *value,
+static int handle_direct_counter_write(const char *key, char *value, psabpf_bpf_map_descriptor_t *map,
                                        psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry, uint64_t bpf_flags)
 {
     /* 1. Entry provided - build counter based on it (on update and add)
@@ -1162,12 +1172,12 @@ static int handle_direct_counter_write(const char *key, char *value,
 
     if (bpf_flags == BPF_EXIST) {
         char *old_value_buffer = NULL;
-        old_value_buffer = malloc(ctx->table.value_size);
+        old_value_buffer = malloc(map->value_size);
         if (old_value_buffer == NULL)
             return ENOMEM;
-        memset(old_value_buffer, 0, ctx->table.value_size);
+        memset(old_value_buffer, 0, map->value_size);
 
-        int err = bpf_map_lookup_elem(ctx->table.fd, key, old_value_buffer);
+        int err = bpf_map_lookup_elem(map->fd, key, old_value_buffer);
         if (err != 0) {
             free(old_value_buffer);
             return ENOENT;
@@ -1221,7 +1231,7 @@ static int handle_direct_meter_write(char *value, psabpf_table_entry_ctx_t *ctx,
     return NO_ERROR;
 }
 
-static int handle_direct_objects_write(const char *key, char *value,
+static int handle_direct_objects_write(const char *key, char *value, psabpf_bpf_map_descriptor_t *map,
                                        psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry, uint64_t bpf_flags)
 {
     if (ctx->is_indirect || ctx->btf_metadata.btf == NULL || ctx->table.btf_type_id == 0)
@@ -1231,7 +1241,7 @@ static int handle_direct_objects_write(const char *key, char *value,
     if (ret != NO_ERROR)
         return ret;
 
-    return handle_direct_counter_write(key, value, ctx, entry, bpf_flags);
+    return handle_direct_counter_write(key, value, map, ctx, entry, bpf_flags);
 }
 
 struct ternary_table_prefix_metadata {
@@ -1593,7 +1603,7 @@ static int psabpf_table_entry_write(psabpf_table_entry_ctx_t *ctx, psabpf_table_
         mem_bitwise_and((uint32_t *) key_buffer, (uint32_t *) key_mask_buffer, ctx->table.key_size);
 
     /* Handle direct objects */
-    return_code = handle_direct_objects_write(key_buffer, value_buffer, ctx, entry, bpf_flags);
+    return_code = handle_direct_objects_write(key_buffer, value_buffer, &ctx->table, ctx, entry, bpf_flags);
     if (return_code != NO_ERROR) {
         fprintf(stderr, "failed to handle direct objects: %s\n", strerror(return_code));
         goto clean_up;
@@ -1853,6 +1863,70 @@ clean_up:
         free(key_buffer);
     if (key_mask_buffer != NULL)
         free(key_mask_buffer);
+
+    return return_code;
+}
+
+int psabpf_table_entry_set_default_entry(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry)
+{
+    uint64_t key = 0;
+    char *value_buffer = NULL;
+    int return_code = NO_ERROR;
+
+    if (ctx == NULL || entry == NULL)
+        return EINVAL;
+
+    if (ctx->default_entry.fd < 0) {
+        fprintf(stderr, "can't add default entry: table not opened or table has no default entry\n");
+        return EBADF;
+    }
+    if (ctx->default_entry.key_size == 0 || ctx->default_entry.key_size > sizeof(key) ||
+        ctx->default_entry.value_size == 0 || ctx->default_entry.value_size != ctx->table.value_size) {
+        fprintf(stderr, "key size or value is not supported\n");
+        return ENOTSUP;
+    }
+    if (entry->action == NULL) {
+        fprintf(stderr, "missing action specification\n");
+        return ENODATA;
+    }
+
+    /* prepare buffer for map value */
+    value_buffer = malloc(ctx->default_entry.value_size);
+    if (value_buffer == NULL) {
+        fprintf(stderr, "not enough memory\n");
+        return ENOMEM;
+    }
+
+    return_code = construct_buffer(value_buffer, ctx->default_entry.value_size, ctx, entry,
+                                   fill_value_btf_info, fill_value_byte_by_byte);
+    if (return_code != NO_ERROR) {
+        fprintf(stderr, "failed to construct value\n");
+        goto clean_up;
+    }
+
+    /* Handle direct objects - default entry always exists
+     * and is treated like a regular entry, including with regards to direct resources */
+    return_code = handle_direct_objects_write((void *) &key, value_buffer, &ctx->default_entry, ctx, entry, BPF_EXIST);
+    if (return_code != NO_ERROR) {
+        fprintf(stderr, "failed to handle direct objects: %s\n", strerror(return_code));
+        goto clean_up;
+    }
+
+    /* update map */
+    return_code = bpf_map_update_elem(ctx->default_entry.fd, &key, value_buffer, BPF_ANY);
+    if (return_code != 0) {
+        return_code = errno;
+        fprintf(stderr, "failed to set up entry: %s\n", strerror(errno));
+    } else {
+        return_code = clear_table_cache(&ctx->cache);
+        if (return_code != NO_ERROR) {
+            fprintf(stderr, "failed to clear cache: %s\n", strerror(return_code));
+        }
+    }
+
+    clean_up:
+    if (value_buffer != NULL)
+        free(value_buffer);
 
     return return_code;
 }

--- a/lib/psabpf_table.c
+++ b/lib/psabpf_table.c
@@ -1924,7 +1924,7 @@ int psabpf_table_entry_set_default_entry(psabpf_table_entry_ctx_t *ctx, psabpf_t
         }
     }
 
-    clean_up:
+clean_up:
     if (value_buffer != NULL)
         free(value_buffer);
 


### PR DESCRIPTION
Usage: `psabpf-ctl table default set pipe ID TABLE ACTION [data ACTION_PARAMS]`

Added keyword `set` after `default` due to early possibility to distinguish set and get operation.