### PR TITLE
psabpf: Add shared library generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2")
 
-set(PSABPFCTL_SRCS
+OPTION (BUILD_SHARED "Build a shared library which the psabpf-ctl program will link against. Useful for other programs to link against as well." OFF)
+
+set(PSABPFLIB_SRCS
         lib/btf.c
         lib/common.c
         lib/psabpf.c
@@ -33,7 +35,9 @@ set(PSABPFCTL_SRCS
         lib/psabpf_meter.c
         lib/psabpf_counter.c
         lib/psabpf_direct_counter.c
-        lib/psabpf_direct_meter.c
+        lib/psabpf_direct_meter.c)
+
+set(PSABPFCTL_SRCS
         CLI/action_selector.c
         CLI/common.c
         CLI/clone_session.c
@@ -45,9 +49,21 @@ set(PSABPFCTL_SRCS
         CLI/counter.c
         main.c)
 
-add_executable(psabpf-ctl ${PSABPFCTL_SRCS})
+if (BUILD_SHARED)
+  add_library(psabpf SHARED ${PSABPFLIB_SRCS})
+  target_link_libraries(psabpf ${CMAKE_CURRENT_SOURCE_DIR}/install/usr/lib64/libbpf.a z elf)
+  install(TARGETS psabpf DESTINATION lib)
+  add_executable(psabpf-ctl ${PSABPFCTL_SRCS})
+else ()
+  add_executable(psabpf-ctl ${PSABPFLIB_SRCS} ${PSABPFCTL_SRCS})
+endif ()
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/install/usr/include)
-target_link_libraries(psabpf-ctl ${CMAKE_CURRENT_SOURCE_DIR}/install/usr/lib64/libbpf.a)
-target_link_libraries(psabpf-ctl z elf gmp m jansson)
+if (BUILD_SHARED)
+  link_directories(${CMAKE_CURRENT_BINARY_DIR})
+  target_link_libraries(psabpf-ctl psabpf z elf gmp m jansson)
+else ()
+  target_link_libraries(psabpf-ctl z elf gmp m jansson)
+endif ()
+target_link_libraries(psabpf-ctl ${CMAKE_CURRENT_SOURCE_DIR}/install/usr/lib64/libbpf.a z elf)
 install(TARGETS psabpf-ctl RUNTIME DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -12,12 +12,33 @@
    ./build_libbpf.sh
    ```
 4. Build the code and install binary file:
+   To build a static psabpf-ctl binary:
    ```shell
    mkdir build
    cd build
    cmake ..
    make -j4
    sudo make install
+   ```
+
+   To build a shared library which the psabpf-ctl binary will link against:
+
+   ```shell
+   mkdir build
+   cd build
+   cmake -DBUILD_SHARED=on ..
+   make -j4
+   sudo make install
+   ```
+
+   Make sure to add /usr/local/lib to your shared library path, something like
+   the following will work:
+
+   Make sure to add /usr/local/lib to your shared library path. You can do this
+   by adding this to your .bashrc:
+
+   ```shell
+   export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
    ```
 
 Note that `psabpf-ctl` is statically linked with shipped `libbpf`, so there is no need to install this library system-wide.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,26 @@
 1. Make sure you have installed dependencies:
+
    ```shell
    sudo apt install iproute2 make cmake gcc git libgmp-dev libelf-dev zlib1g-dev libjansson-dev
    ```
+
 2. Get the code with submodules:
+
    ```shell
    git clone --recursive https://github.com/P4-Research/psabpf.git
    cd psabpf
    ```
+
 3. Build dependencies:
+
    ```shell
    ./build_libbpf.sh
    ```
+
 4. Build the code and install binary file:
+
    To build a static psabpf-ctl binary:
+
    ```shell
    mkdir build
    cd build
@@ -21,21 +29,20 @@
    sudo make install
    ```
 
-   To build a shared library which the psabpf-ctl binary will link against:
+5. cmake options:
+
+   There is a single option to the cmake command, which will change how psabpf
+   is built to generate a shared library in addition to the psabpf-ctl CLI.
+   This will also allow other programs to link against the libpsabpf shared
+   library. To use this option, run the cmake command as below:
 
    ```shell
-   mkdir build
-   cd build
    cmake -DBUILD_SHARED=on ..
-   make -j4
-   sudo make install
    ```
 
-   Make sure to add /usr/local/lib to your shared library path, something like
-   the following will work:
-
-   Make sure to add /usr/local/lib to your shared library path. You can do this
-   by adding this to your .bashrc:
+   If you have built with the shared library on, you will want to ensure to add
+   /usr/local/lib to your shared library path, something like the following
+   will work:
 
    ```shell
    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH

--- a/build_libbpf.sh
+++ b/build_libbpf.sh
@@ -24,4 +24,4 @@ TARGET_DIR=$ROOT_PATH/install
 
 mkdir -p "$BUILD_DIR" "$TARGET_DIR"
 
-make -C "$SRC_DIR" "-j$(nproc)" install install_uapi_headers BUILD_STATIC_ONLY=y "OBJDIR=$BUILD_DIR" "DESTDIR=$TARGET_DIR"
+make -C "$SRC_DIR" "-j$(nproc)" install install_uapi_headers BUILD_STATIC_ONLY=y "OBJDIR=$BUILD_DIR" "DESTDIR=$TARGET_DIR" CFLAGS="-fPIC -g -O2 -Werror -Wall"


### PR DESCRIPTION
Enable shared library support by:

* Modifying build_libbpf.sh to pass CFLAGS, including -fPIC.
* Modify CMakeLists.txt to generate a shared library for psabpf.

Signed-off-by: Kyle Mestery <mestery@mestery.com>