### PR TITLE
CI: Initial GitHub Actions support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: ipdk-plugin CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  # if workflow for PR or push is already running stop it, and start new one
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Build static library version of psabpf
+    - name: Run static build
+      run: |
+        ./build_libbpf.sh
+        mkdir build && pushd build || exit
+        cmake ..
+        make -j4
+        make install
+        popd || exit
+
+    # Build shared library version of psabpf
+    # NOTE: Assumes we already built libbpf here
+    - name: Run static build
+      run: |
+        mkdir build_shared && pushd build_shared || exit
+        cmake -DBUILD_SHARED=on ..
+        make -j4
+        make install
+        popd || exit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,9 @@
-name: ipdk-plugin CI
+name: psabpf CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
 
 concurrency:
   # if workflow for PR or push is already running stop it, and start new one
@@ -18,13 +17,18 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    # Install dependencies
+    - name: Install dependencies
+      run: |
+        sudo apt -y install iproute2 make cmake gcc git libgmp-dev libelf-dev zlib1g-dev libjansson-dev
+
     # Build static library version of psabpf
     - name: Run static build
       run: |
         ./build_libbpf.sh
         mkdir build && pushd build || exit
         cmake ..
-        make -j4
+        make -j$(nproc)
         make install
         popd || exit
 


### PR DESCRIPTION
This commit adds the logic to enable GitHub Actions CI for both pull
requests and merges to the psabpf repository.

Signed-off-by: Kyle Mestery <mestery@mestery.com>