### PR TITLE
Add support for dump all table entries with table get command

### DIFF
--- a/CLI/table.c
+++ b/CLI/table.c
@@ -660,7 +660,7 @@ static int build_json_table_metadata(psabpf_table_entry_ctx_t *ctx, json_t *pare
     return NO_ERROR;
 }
 
-static int print_json_table_entry(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry, const char *table_name)
+static int print_json_table(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry, const char *table_name)
 {
     int ret = EINVAL;
     json_t *root = json_object();
@@ -905,7 +905,7 @@ int do_table_get(int argc, char **argv)
         if (error_code != NO_ERROR)
             goto clean_up;
     }
-    error_code = print_json_table_entry(&ctx, key_provided ? &entry : NULL, table_name);
+    error_code = print_json_table(&ctx, key_provided ? &entry : NULL, table_name);
 
 clean_up:
     psabpf_table_entry_free(&entry);

--- a/include/psabpf.h
+++ b/include/psabpf.h
@@ -412,9 +412,10 @@ typedef struct psabpf_table_entry_context {
     psabpf_struct_field_descriptor_set_t table_implementations;
     psabpf_struct_field_descriptor_set_t table_implementation_group_marks;
 
-    // below fields might be useful when iterating
-    size_t curr_idx;
-    psabpf_table_entry_t *prev;
+    /* for iteration over table */
+    void *current_raw_key;
+    void *current_raw_key_mask;
+    psabpf_table_entry_t current_entry;
 } psabpf_table_entry_ctx_t;
 
 void psabpf_table_entry_ctx_init(psabpf_table_entry_ctx_t *ctx);
@@ -480,7 +481,7 @@ int psabpf_table_entry_add(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *
 int psabpf_table_entry_update(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry);
 int psabpf_table_entry_del(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry);
 int psabpf_table_entry_get(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry);
-int psabpf_table_entry_get_next(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry);
+psabpf_table_entry_t *psabpf_table_entry_get_next(psabpf_table_entry_ctx_t *ctx);
 
 int psabpf_table_entry_set_default_entry(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry);
 int psabpf_table_entry_get_default_entry(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry);

--- a/lib/common.c
+++ b/lib/common.c
@@ -42,6 +42,17 @@ void mem_bitwise_and(uint32_t *dst, uint32_t *mask, size_t len)
     }
 }
 
+void swap_byte_order(uint8_t *data, size_t len)
+{
+    for (size_t i = 0; i < len / 2; ++i) {
+        uint8_t *byte1 = data + i;
+        uint8_t *byte2 = data + len - 1 - i;
+        uint8_t tmp = *byte1;
+        *byte1 = *byte2;
+        *byte2 = tmp;
+    }
+}
+
 void close_object_fd(int *fd)
 {
     if (*fd >= 0)

--- a/lib/common.c
+++ b/lib/common.c
@@ -42,12 +42,12 @@ void mem_bitwise_and(uint32_t *dst, uint32_t *mask, size_t len)
     }
 }
 
-void swap_byte_order(uint8_t *data, size_t len)
+void swap_byte_order(char *data, size_t len)
 {
     for (size_t i = 0; i < len / 2; ++i) {
-        uint8_t *byte1 = data + i;
-        uint8_t *byte2 = data + len - 1 - i;
-        uint8_t tmp = *byte1;
+        char *byte1 = data + i;
+        char *byte2 = data + len - 1 - i;
+        char tmp = *byte1;
         *byte1 = *byte2;
         *byte2 = tmp;
     }

--- a/lib/common.h
+++ b/lib/common.h
@@ -25,6 +25,7 @@ int str_ends_with(const char *str, const char *suffix);
 
 /* Data len must be aligned to 4B */
 void mem_bitwise_and(uint32_t *dst, uint32_t *mask, size_t len);
+void swap_byte_order(uint8_t *data, size_t len);
 
 void close_object_fd(int *fd);
 

--- a/lib/common.h
+++ b/lib/common.h
@@ -25,7 +25,7 @@ int str_ends_with(const char *str, const char *suffix);
 
 /* Data len must be aligned to 4B */
 void mem_bitwise_and(uint32_t *dst, uint32_t *mask, size_t len);
-void swap_byte_order(uint8_t *data, size_t len);
+void swap_byte_order(char *data, size_t len);
 
 void close_object_fd(int *fd);
 

--- a/lib/psabpf_table.c
+++ b/lib/psabpf_table.c
@@ -2740,7 +2740,6 @@ static int get_next_ternary_table_key_mask(psabpf_table_entry_ctx_t *ctx)
         goto clean_up;
     }
 
-    /* Avoid infinite loop by iteration for every possible mask. */
     for (unsigned i = 0; i < ctx->prefixes.max_entries; ++i) {
         /* Let's see if current mask has next key entry. */
         if (ctx->table.fd >= 0) {

--- a/lib/psabpf_table.c
+++ b/lib/psabpf_table.c
@@ -2644,13 +2644,7 @@ static int parse_table_key_add_key_field(psabpf_table_entry_t *entry, int field_
         psabpf_matchkey_type(&mk, PSABPF_LPM);
         psabpf_matchkey_data(&mk, field_data, field_len);
         /* Convert network byte order into host order */
-        for (size_t i = 0; i < mk.key_size / 2; ++i) {
-            uint8_t *byte1 = (uint8_t *) (mk.data + i);
-            uint8_t *byte2 = (uint8_t *) (mk.data + mk.key_size - 1 - i);
-            uint8_t tmp = *byte1;
-            *byte1 = *byte2;
-            *byte2 = tmp;
-        }
+        swap_byte_order(mk.data, mk.key_size);
         psabpf_matchkey_prefix_len(&mk, prefix);
     } else if (field_type == PSABPF_EXACT) {
         psabpf_matchkey_type(&mk, PSABPF_EXACT);

--- a/lib/psabpf_table.c
+++ b/lib/psabpf_table.c
@@ -2740,7 +2740,8 @@ static int get_next_ternary_table_key_mask(psabpf_table_entry_ctx_t *ctx)
         goto clean_up;
     }
 
-    while (true) {
+    /* Avoid infinite loop by iteration for every possible mask. */
+    for (unsigned i = 0; i < ctx->prefixes.max_entries; ++i) {
         /* Let's see if current mask has next key entry. */
         if (ctx->table.fd >= 0) {
             if (bpf_map_get_next_key(ctx->table.fd, ctx->current_raw_key, next_key) == 0)


### PR DESCRIPTION
Closes #23 

Allows to dump all entries from a table. Default entry will be added in a separate PR.