### PR TITLE
Use libbpf to create & attach eBPF programs to TC hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Psabpf depends on following libraries and utilities:
 - [CMake](https://cmake.org/)
 - C compiler, GCC is tested
 - [git](https://git-scm.com/) for version control
-- [iproute2](https://wiki.linuxfoundation.org/networking/iproute2) (dependency might be removed in the future, see issue #1)
 - GNU Multiple Precision Arithmetic Library [GMP](http://gmplib.org/)
 - [libelf](https://sourceware.org/elfutils/)
 - [zlib](http://zlib.net/)
@@ -19,7 +18,7 @@ Psabpf depends on following libraries and utilities:
 All the dependencies can be installed on Ubuntu 20.04 with the following command:
 
 ```shell
-sudo apt install iproute2 make cmake gcc git libgmp-dev libelf-dev zlib1g-dev libjansson-dev
+sudo apt install make cmake gcc git libgmp-dev libelf-dev zlib1g-dev libjansson-dev
 ```
 
 Note that `psabpf-ctl` is statically linked with shipped `libbpf`, so there is no need to install this library

--- a/lib/psabpf_pipeline.c
+++ b/lib/psabpf_pipeline.c
@@ -15,8 +15,10 @@
  * limitations under the License.
  */
 
-/* For ftw.h - use newer function from POSIX 1995 */
+/* For ftw.h - use newer function from POSIX 1995. Other functions might be affected
+ * if behaviour was changed between this release and default one */
 #define _XOPEN_SOURCE 500
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -428,6 +430,12 @@ static int remove_pipeline_directory(psabpf_context_t *ctx)
     char pipeline_path[256];
     build_ebpf_pipeline_path(pipeline_path, sizeof(pipeline_path), ctx);
 
+    /* 16 - Maximum number of file descriptors used by nftw(). In case lack of
+     *      available file descriptors it can be reduced at the cost of performance.
+     * FTW_DEPTH - Call callback for the directory itself after handling the
+     *             contents of the directory and its subdirectories.
+     * FTW_MOUNT - Stay within the same filesystem (i.e., do not cross mount points).
+     * FTW_PHYS  - Do  not  follow  symbolic  links. */
     if (nftw(pipeline_path, remove_file, 16, FTW_DEPTH | FTW_MOUNT | FTW_PHYS) != 0) {
         int err = errno;
         fprintf(stderr, "failed to remove pipeline directory: %s\n", strerror(err));

--- a/lib/psabpf_pipeline.c
+++ b/lib/psabpf_pipeline.c
@@ -101,7 +101,10 @@ static int tc_attach_prog(psabpf_context_t *ctx, const char *prog, int ifindex, 
     if (bpf_tc_attach(&hook, &opts) != 0) {
         ret = errno;
         fprintf(stderr, "failed to attach bpf program to interface %s: %s\n", interface, strerror(ret));
+        goto clean_up;
     }
+
+clean_up:
     close(fd);
 
     return ret;


### PR DESCRIPTION
Closes #1 

- [x] Use `libbpf` to create TC qdisc and attach bpf programs.
- [x] Use `libbpf` to destroy TC qdisc with attached bpf programs.
- [x] Removed `iproute2` dependency.
- [x] Use POSIX API to remove pipeline directory instead of executing `rm` in new process.
- [x] Test on kernel 5.8 (PTF tests passed locally).

PTF tests: https://github.com/tatry/p4c/pull/13

`libbpf` updated from v0.3.0 to v0.5.0:
* v0.4.0 introduces TC hook point API
* v0.5.0 provides some small bugfixes to that API

After patch, you have to re-call build_libbpf.sh script.

For curiosity, there is small PTF tests performance comparison (command: `time sudo ./test.sh`,  no repeated):
- CLI from master:
```
	real    4m34,150s
	user    1m52,277s
	sys     0m13,671s
```

- Using only `libbpf` to manage TC qdisc:
```
	real    4m23,721s
	user    1m44,708s
	sys     0m12,842s
```
- Using `libbpf` to manage TC qdisc and POSIX to remove pipeline directory:
```
	real    4m18,553s
	user    1m44,227s
	sys     0m13,132s
```