### PR TITLE
Fix prefix length calculation in LPM tables for exact match type keys

### DIFF
--- a/lib/psabpf_table.c
+++ b/lib/psabpf_table.c
@@ -1037,7 +1037,10 @@ int fill_key_byte_by_byte(char * buffer, psabpf_table_entry_ctx_t *ctx, psabpf_t
             uint32_t prefix_len = mk->key_size * 8;
             if (mk->type == PSABPF_LPM)
                 prefix_len = mk->u.lpm.prefix_len;
-            // TODO: error for ternary type match key
+            else if (mk->type == PSABPF_TERNARY) {
+                fprintf(stderr, "ternary key is not allowed for this table\n");
+                return EINVAL;
+            }
             *lpm_prefix = (buffer - ((char *) lpm_prefix) - 4) * 8 + prefix_len;
         }
 
@@ -1132,7 +1135,10 @@ int fill_key_btf_info(char * buffer, psabpf_table_entry_ctx_t *ctx, psabpf_table
                 uint32_t prefix_value = ctx->table.key_size * 8 - 32;
                 if (mk->type == PSABPF_LPM)
                     prefix_value = offset * 8 + mk->u.lpm.prefix_len - 32;
-                // TODO: error for ternary key match type
+                else if (mk->type == PSABPF_TERNARY) {
+                    fprintf(stderr, "ternary key is not allowed for this table\n");
+                    return EINVAL;
+                }
                 ret = write_buffer_btf(buffer, ctx->table.key_size, prefix_md.bit_offset / 8,
                                        &prefix_value, sizeof(prefix_value), ctx,
                                        prefix_md.effective_type_id, "prefix", WRITE_HOST_ORDER);


### PR DESCRIPTION
Closes #64 
PTF tests: https://github.com/tatry/p4c/pull/18

Fixes the conversion between LPM and exact match type key match types during write operation. Now all exact keys are treated as LPM keys with prefix length equal to its length when needed.