### PR TITLE
T16: Extend ActionSelector to support ActionProfile

### DIFF
--- a/CLI/action_selector.c
+++ b/CLI/action_selector.c
@@ -364,14 +364,16 @@ int print_action_selector(psabpf_action_selector_context_t *ctx, const char *ins
     bool failed = false;
     if (mode == GET_MODE_ALL) {
         members = create_json_all_members(ctx);
-        if (members == NULL)
+        if (members == NULL) {
             failed = true;
+        }
 
         if (psabpf_action_selector_has_group_capability(ctx)) {
             groups = create_json_all_groups(ctx);
             empty_group_action = create_json_empty_group_action(ctx);
-            if (groups == NULL || empty_group_action == NULL)
+            if (groups == NULL || empty_group_action == NULL) {
                 failed = true;
+            }
         }
     } else if (mode == GET_MODE_MEMBER) {
         members = json_object();

--- a/CLI/action_selector.h
+++ b/CLI/action_selector.h
@@ -31,6 +31,7 @@ int do_action_selector_empty_group_action(int argc, char **argv);
 int do_action_selector_get(int argc, char **argv);
 
 int do_action_selector_help(int argc, char **argv);
+int do_action_profile_help(int argc, char **argv);
 
 static const struct cmd action_selector_cmds[] = {
         {"help",                 do_action_selector_help},
@@ -42,6 +43,15 @@ static const struct cmd action_selector_cmds[] = {
         {"add-to-group",         do_action_selector_add_to_group},
         {"delete-from-group",    do_action_selector_delete_from_group},
         {"empty-group-action",   do_action_selector_empty_group_action},
+        {"get",                  do_action_selector_get},
+        {0}
+};
+
+static const struct cmd action_profile_cmds[] = {
+        {"help",                 do_action_profile_help},
+        {"add-member",           do_action_selector_add_member},
+        {"delete-member",        do_action_selector_delete_member},
+        {"update-member",        do_action_selector_update_member},
         {"get",                  do_action_selector_get},
         {0}
 };

--- a/include/psabpf.h
+++ b/include/psabpf.h
@@ -29,8 +29,6 @@
  */
 
 typedef struct psabpf_btf {
-    /* BTF metadata are associated with eBPF program, eBPF map may do not own BTF */
-    int associated_prog;
     void * btf;
     /* To create bpf maps with BTF info */
     int btf_fd;
@@ -42,9 +40,12 @@ typedef struct psabpf_bpf_map_descriptor {
     uint32_t key_size;
     uint32_t value_size;
     uint32_t max_entries;
-    uint32_t btf_type_id;  // TODO: remove, use instead key_type_id and value_type_id
+    /* Effective type IDs for key/value */
     uint32_t key_type_id;
     uint32_t value_type_id;
+    /* Type IDs used by map definition for key/value */
+    uint32_t map_key_type_id;
+    uint32_t map_value_type_id;
 } psabpf_bpf_map_descriptor_t;
 
 /*

--- a/include/psabpf.h
+++ b/include/psabpf.h
@@ -536,7 +536,7 @@ const char *psabpf_direct_meter_get_name(psabpf_direct_meter_context_t *dm_ctx);
 int psabpf_direct_meter_get_entry(psabpf_direct_meter_context_t *dm_ctx, psabpf_table_entry_t *entry, psabpf_meter_entry_t *dm);
 
 /*
- * Action Selector
+ * Action Selector and Action Profile
  */
 
 typedef struct psabpf_action_selector_member_context {
@@ -575,6 +575,8 @@ void psabpf_action_selector_member_free(psabpf_action_selector_member_context_t 
 
 void psabpf_action_selector_group_init(psabpf_action_selector_group_context_t *group);
 void psabpf_action_selector_group_free(psabpf_action_selector_group_context_t *group);
+
+bool psabpf_action_selector_has_group_capability(psabpf_action_selector_context_t *ctx);
 
 /* Reuse table API */
 int psabpf_action_selector_member_action(psabpf_action_selector_member_context_t *member, psabpf_action_t *action);
@@ -621,10 +623,6 @@ psabpf_action_param_t *psabpf_action_selector_action_param_get_next(psabpf_actio
 const char *psabpf_action_selector_action_param_get_name(psabpf_action_selector_context_t *ctx,
                                                          psabpf_action_selector_member_context_t *member,
                                                          psabpf_action_param_t *param);
-
-/*
- * TODO: Action Profile
- */
 
 ////// PacketIn / PacketOut
 // TODO: to be implemented

--- a/lib/btf.c
+++ b/lib/btf.c
@@ -217,15 +217,17 @@ static int try_load_btf(psabpf_btf_t *btf, const char *program_name)
 {
     /* BTF metadata are associated with eBPF program, eBPF map may do not own BTF */
     int associated_prog = bpf_obj_get(program_name);
-    if (associated_prog < 0)
+    if (associated_prog < 0) {
         return ENOENT;
+    }
 
     struct bpf_prog_info prog_info = {};
     unsigned len = sizeof(struct bpf_prog_info);
     int error = bpf_obj_get_info_by_fd(associated_prog, &prog_info, &len);
     close(associated_prog);
-    if (error)
+    if (error) {
         return ENOENT;
+    }
 
     error = btf__get_from_id(prog_info.btf_id, (struct btf **) &(btf->btf));
     btf->btf_fd = bpf_btf_get_fd_by_id(prog_info.btf_id);
@@ -301,15 +303,17 @@ int open_bpf_map(psabpf_context_t *psabpf_ctx, const char *name, psabpf_btf_t *b
         if (btf_type_id == 0)
             fprintf(stderr, "can't get BTF info for %s\n", name);
 
-        if (md->map_key_type_id == 0)
+        if (md->map_key_type_id == 0) {
             md->key_type_id = get_member_type_id_by_name(btf->btf, btf_type_id, "key");
-        else
+        } else {
             md->key_type_id = follow_types(btf->btf, md->map_key_type_id);
+        }
 
-        if (md->map_value_type_id == 0)
+        if (md->map_value_type_id == 0) {
             md->value_type_id = get_member_type_id_by_name(btf->btf, btf_type_id, "value");
-        else
+        } else {
             md->value_type_id = follow_types(btf->btf, md->map_value_type_id);
+        }
     }
 
     return NO_ERROR;

--- a/lib/btf.c
+++ b/lib/btf.c
@@ -169,7 +169,7 @@ int psabtf_get_member_md_by_index(struct btf *btf, uint32_t type_id, uint16_t in
     return NO_ERROR;
 }
 
-uint32_t psabtf_get_member_type_id_by_name(struct btf *btf, uint32_t type_id, const char *member_name)
+static uint32_t get_member_type_id_by_name(struct btf *btf, uint32_t type_id, const char *member_name)
 {
     psabtf_struct_member_md_t md = {};
     if (psabtf_get_member_md_by_name(btf, type_id, member_name, &md) != 0)
@@ -210,21 +210,22 @@ size_t psabtf_get_type_size_by_id(struct btf *btf, uint32_t type_id)
 void init_btf(psabpf_btf_t *btf)
 {
     btf->btf = NULL;
-    btf->associated_prog = -1;
     btf->btf_fd = -1;
 }
 
 static int try_load_btf(psabpf_btf_t *btf, const char *program_name)
 {
-    btf->associated_prog = bpf_obj_get(program_name);
-    if (btf->associated_prog < 0)
+    /* BTF metadata are associated with eBPF program, eBPF map may do not own BTF */
+    int associated_prog = bpf_obj_get(program_name);
+    if (associated_prog < 0)
         return ENOENT;
 
     struct bpf_prog_info prog_info = {};
     unsigned len = sizeof(struct bpf_prog_info);
-    int error = bpf_obj_get_info_by_fd(btf->associated_prog, &prog_info, &len);
+    int error = bpf_obj_get_info_by_fd(associated_prog, &prog_info, &len);
+    close(associated_prog);
     if (error)
-        goto free_program;
+        return ENOENT;
 
     error = btf__get_from_id(prog_info.btf_id, (struct btf **) &(btf->btf));
     btf->btf_fd = bpf_btf_get_fd_by_id(prog_info.btf_id);
@@ -238,9 +239,6 @@ free_btf:
         btf__free(btf->btf);
     btf->btf = NULL;
     close_object_fd(&btf->btf_fd);
-
-free_program:
-    close_object_fd(&btf->associated_prog);
 
     return ENOENT;
 }
@@ -274,7 +272,6 @@ void free_btf(psabpf_btf_t *btf)
     if (btf->btf)
         btf__free(btf->btf);
     btf->btf = NULL;
-    close_object_fd(&btf->associated_prog);
     close_object_fd(&btf->btf_fd);
 }
 
@@ -296,11 +293,23 @@ int open_bpf_map(psabpf_context_t *psabpf_ctx, const char *name, psabpf_btf_t *b
     if (errno_val != NO_ERROR)
         return errno_val;
 
-    /* Find entry in BTF for our map */
+    /* Find BTF type IDs for our map */
+    md->key_type_id = 0;
+    md->value_type_id = 0;
     if (btf != NULL && btf->btf != NULL) {
-        md->btf_type_id = psabtf_get_map_type_id_by_name(btf->btf, name);
-        if (md->btf_type_id == 0)
+        uint32_t btf_type_id = psabtf_get_map_type_id_by_name(btf->btf, name);
+        if (btf_type_id == 0)
             fprintf(stderr, "can't get BTF info for %s\n", name);
+
+        if (md->map_key_type_id == 0)
+            md->key_type_id = get_member_type_id_by_name(btf->btf, btf_type_id, "key");
+        else
+            md->key_type_id = follow_types(btf->btf, md->map_key_type_id);
+
+        if (md->map_value_type_id == 0)
+            md->value_type_id = get_member_type_id_by_name(btf->btf, btf_type_id, "value");
+        else
+            md->value_type_id = follow_types(btf->btf, md->map_value_type_id);
     }
 
     return NO_ERROR;
@@ -326,8 +335,8 @@ int update_map_info(psabpf_bpf_map_descriptor_t *md)
     md->key_size = info.key_size;
     md->value_size = info.value_size;
     md->max_entries = info.max_entries;
-    md->key_type_id = info.btf_key_type_id;
-    md->value_type_id = info.btf_value_type_id;
+    md->map_key_type_id = info.btf_key_type_id;
+    md->map_value_type_id = info.btf_value_type_id;
 
     return NO_ERROR;
 }

--- a/lib/btf.h
+++ b/lib/btf.h
@@ -36,8 +36,6 @@ int psabtf_get_member_md_by_name(struct btf *btf, uint32_t type_id,
         const char *member_name, psabtf_struct_member_md_t *md);
 int psabtf_get_member_md_by_index(struct btf *btf, uint32_t type_id, uint16_t index,
         psabtf_struct_member_md_t *md);
-uint32_t psabtf_get_member_type_id_by_name(struct btf *btf, uint32_t type_id,
-        const char *member_name);
 
 size_t psabtf_get_type_size_by_id(struct btf *btf, uint32_t type_id);
 

--- a/lib/psabpf_action_selector.c
+++ b/lib/psabpf_action_selector.c
@@ -465,8 +465,8 @@ int psabpf_action_selector_add_group(psabpf_action_selector_context_t *ctx, psab
             .max_entries = ctx->group.max_entries,
             .map_type = ctx->group.type,
             .btf_fd = ctx->btf.btf_fd,
-            .btf_key_type_id = ctx->group.key_type_id,
-            .btf_value_type_id = ctx->group.value_type_id,
+            .btf_key_type_id = ctx->group.map_key_type_id,
+            .btf_value_type_id = ctx->group.map_value_type_id,
     };
     ctx->group.fd = bpf_create_map_xattr(&attr);
     if (ctx->group.fd < 0) {

--- a/lib/psabpf_action_selector.c
+++ b/lib/psabpf_action_selector.c
@@ -151,7 +151,9 @@ static int do_open_action_selector(psabpf_context_t *psabpf_ctx, psabpf_action_s
     snprintf(derived_name, sizeof(derived_name), "%s_groups_inner", name);
     ret = open_bpf_map(psabpf_ctx, derived_name, &ctx->btf, &ctx->group);
     if (ret != NO_ERROR) {
-        fprintf(stderr, "couldn't open map %s: %s\n", derived_name, strerror(ret));
+        /* Maybe ActionSelector is an ActionProfile so do not bother user in this case */
+        if (ret != ENOENT)
+            fprintf(stderr, "couldn't open map %s: %s\n", derived_name, strerror(ret));
         return ret;
     }
     close_object_fd(&ctx->group.fd);
@@ -186,6 +188,17 @@ static int do_open_action_selector(psabpf_context_t *psabpf_ctx, psabpf_action_s
     return NO_ERROR;
 }
 
+static int do_open_action_profile(psabpf_context_t *psabpf_ctx, psabpf_action_selector_context_t *ctx, const char *name)
+{
+    int ret = open_bpf_map(psabpf_ctx, name, &ctx->btf, &ctx->map_of_members);
+    if (ret != NO_ERROR) {
+        fprintf(stderr, "couldn't open map %s: %s\n", name, strerror(ret));
+        return ret;
+    }
+
+    return NO_ERROR;
+}
+
 int psabpf_action_selector_ctx_name(psabpf_context_t *psabpf_ctx, psabpf_action_selector_context_t *ctx, const char *name)
 {
     if (ctx == NULL || psabpf_ctx == NULL || name == NULL)
@@ -196,8 +209,10 @@ int psabpf_action_selector_ctx_name(psabpf_context_t *psabpf_ctx, psabpf_action_
         fprintf(stderr, "warning: couldn't find BTF info\n");
 
     int ret = do_open_action_selector(psabpf_ctx, ctx, name);
+    if (ret == ENOENT)
+        ret = do_open_action_profile(psabpf_ctx, ctx, name);
     if (ret != NO_ERROR) {
-        fprintf(stderr, "couldn't open ActionSelector %s: %s\n", name, strerror(ret));
+        fprintf(stderr, "couldn't open ActionSelector/ActionProfile %s: %s\n", name, strerror(ret));
         return ret;
     }
 
@@ -236,6 +251,13 @@ void psabpf_action_selector_group_init(psabpf_action_selector_group_context_t *g
 void psabpf_action_selector_group_free(psabpf_action_selector_group_context_t *group)
 {
     (void) group;
+}
+
+bool psabpf_action_selector_has_group_capability(psabpf_action_selector_context_t *ctx)
+{
+    if (ctx == NULL)
+        return false;
+    return ctx->map_of_groups.fd >= 0;
 }
 
 int psabpf_action_selector_member_action(psabpf_action_selector_member_context_t *member, psabpf_action_t *action)
@@ -323,7 +345,7 @@ int psabpf_action_selector_add_member(psabpf_action_selector_context_t *ctx, psa
 
     member->member_ref = find_and_reserve_reference(&ctx->map_of_members, NULL);
     if (member->member_ref == PSABPF_ACTION_SELECTOR_INVALID_REFERENCE) {
-        fprintf(stderr, "failed to find available reference for member");
+        fprintf(stderr, "failed to find available reference for member\n");
         return EFBIG;  /* Probably, here we know we have access to eBPF, so most probably version is that map is full */
     }
 
@@ -375,6 +397,9 @@ static bool member_in_use(psabpf_action_selector_context_t *ctx, psabpf_action_s
     bool found = false;
     uint32_t key = 0, next_key;
 
+    if (ctx->map_of_groups.fd < 0)
+        return false; /* No groups available */
+
     /* Iterate over every group and check if member reference exists */
     if (bpf_map_get_next_key(ctx->map_of_groups.fd, NULL, &next_key) != 0)
         return false;  /* no groups */
@@ -416,7 +441,7 @@ int psabpf_action_selector_del_member(psabpf_action_selector_context_t *ctx, psa
         fprintf(stderr, "expected that map have 32 bit key\n");
         return EINVAL;
     }
-    if (ctx->group.key_size != 4 || ctx->group.value_size != 4) {
+    if (ctx->map_of_groups.fd >= 0 && (ctx->group.key_size != 4 || ctx->group.value_size != 4)) {
         fprintf(stderr, "invalid group map\n");
         return EINVAL;
     }
@@ -789,6 +814,10 @@ int psabpf_action_selector_get_group(psabpf_action_selector_context_t *ctx, psab
 {
     if (ctx == NULL || group == NULL)
         return EINVAL;
+    if (ctx->map_of_groups.fd < 0) {
+        fprintf(stderr, "map of groups not opened\n");
+        return EINVAL;
+    }
     if (ctx->map_of_groups.key_size != 4 || ctx->map_of_groups.value_size != 4) {
         fprintf(stderr, "invalid map of groups\n");
         return EINVAL;
@@ -810,6 +839,10 @@ psabpf_action_selector_group_context_t *psabpf_action_selector_get_next_group(ps
 {
     if (ctx == NULL)
         return NULL;
+    if (ctx->map_of_groups.fd < 0) {
+        fprintf(stderr, "map of groups not opened\n");
+        return NULL;
+    }
     if (ctx->map_of_groups.key_size != 4) {
         fprintf(stderr, "invalid map of groups\n");
         return NULL;

--- a/lib/psabpf_action_selector.c
+++ b/lib/psabpf_action_selector.c
@@ -152,8 +152,9 @@ static int do_open_action_selector(psabpf_context_t *psabpf_ctx, psabpf_action_s
     ret = open_bpf_map(psabpf_ctx, derived_name, &ctx->btf, &ctx->group);
     if (ret != NO_ERROR) {
         /* Maybe ActionSelector is an ActionProfile so do not bother user in this case */
-        if (ret != ENOENT)
+        if (ret != ENOENT) {
             fprintf(stderr, "couldn't open map %s: %s\n", derived_name, strerror(ret));
+        }
         return ret;
     }
     close_object_fd(&ctx->group.fd);
@@ -209,8 +210,9 @@ int psabpf_action_selector_ctx_name(psabpf_context_t *psabpf_ctx, psabpf_action_
         fprintf(stderr, "warning: couldn't find BTF info\n");
 
     int ret = do_open_action_selector(psabpf_ctx, ctx, name);
-    if (ret == ENOENT)
+    if (ret == ENOENT) {
         ret = do_open_action_profile(psabpf_ctx, ctx, name);
+    }
     if (ret != NO_ERROR) {
         fprintf(stderr, "couldn't open ActionSelector/ActionProfile %s: %s\n", name, strerror(ret));
         return ret;
@@ -255,8 +257,9 @@ void psabpf_action_selector_group_free(psabpf_action_selector_group_context_t *g
 
 bool psabpf_action_selector_has_group_capability(psabpf_action_selector_context_t *ctx)
 {
-    if (ctx == NULL)
+    if (ctx == NULL) {
         return false;
+    }
     return ctx->map_of_groups.fd >= 0;
 }
 
@@ -397,8 +400,9 @@ static bool member_in_use(psabpf_action_selector_context_t *ctx, psabpf_action_s
     bool found = false;
     uint32_t key = 0, next_key;
 
-    if (ctx->map_of_groups.fd < 0)
+    if (ctx->map_of_groups.fd < 0) {
         return false; /* No groups available */
+    }
 
     /* Iterate over every group and check if member reference exists */
     if (bpf_map_get_next_key(ctx->map_of_groups.fd, NULL, &next_key) != 0)

--- a/lib/psabpf_counter.c
+++ b/lib/psabpf_counter.c
@@ -98,10 +98,7 @@ psabpf_counter_type_t get_counter_type(psabpf_btf_t *btf, uint32_t type_id)
 
 static int parse_counter_value(psabpf_counter_context_t *ctx)
 {
-    uint32_t value_type_id;
-    value_type_id = psabtf_get_member_type_id_by_name(ctx->btf_metadata.btf, ctx->counter.btf_type_id, "value");
-
-    ctx->counter_type = get_counter_type(&ctx->btf_metadata, value_type_id);
+    ctx->counter_type = get_counter_type(&ctx->btf_metadata, ctx->counter.value_type_id);
     if (ctx->counter_type == PSABPF_COUNTER_TYPE_UNKNOWN)
         return EINVAL;
 
@@ -117,8 +114,7 @@ static int parse_counter_value(psabpf_counter_context_t *ctx)
 
 static int parse_counter_key(psabpf_counter_context_t *ctx)
 {
-    uint32_t type_id = psabtf_get_member_type_id_by_name(ctx->btf_metadata.btf, ctx->counter.btf_type_id, "key");
-    return parse_struct_type(&ctx->btf_metadata, type_id, ctx->counter.key_size, &ctx->key_fds);
+    return parse_struct_type(&ctx->btf_metadata, ctx->counter.key_type_id, ctx->counter.key_size, &ctx->key_fds);
 }
 
 int psabpf_counter_ctx_name(psabpf_context_t *psabpf_ctx, psabpf_counter_context_t *ctx, const char *name)

--- a/lib/psabpf_digest.c
+++ b/lib/psabpf_digest.c
@@ -48,8 +48,7 @@ void psabpf_digest_ctx_free(psabpf_digest_context_t *ctx)
 
 static int parse_digest_btf(psabpf_digest_context_t *ctx)
 {
-    uint32_t type_id = psabtf_get_member_type_id_by_name(ctx->btf_metadata.btf, ctx->queue.btf_type_id, "value");
-    return parse_struct_type(&ctx->btf_metadata, type_id, ctx->queue.value_size, &ctx->fds);
+    return parse_struct_type(&ctx->btf_metadata, ctx->queue.value_type_id, ctx->queue.value_size, &ctx->fds);
 }
 
 int psabpf_digest_ctx_name(psabpf_context_t *psabpf_ctx, psabpf_digest_context_t *ctx, const char *name)

--- a/lib/psabpf_meter.c
+++ b/lib/psabpf_meter.c
@@ -227,8 +227,7 @@ int psabpf_meter_ctx_name(psabpf_meter_ctx_t *ctx, psabpf_context_t *psabpf_ctx,
     }
 
     /* Parses index type */
-    uint32_t type_id = psabtf_get_member_type_id_by_name(ctx->btf_metadata.btf, ctx->meter.btf_type_id, "key");
-    ret = parse_struct_type(&ctx->btf_metadata, type_id, ctx->meter.key_size, &ctx->index_fds);
+    ret = parse_struct_type(&ctx->btf_metadata, ctx->meter.key_type_id, ctx->meter.key_size, &ctx->index_fds);
     if (ret != NO_ERROR) {
         fprintf(stderr, "failed to parse meter type: %s\n", strerror(ret));
         return ret;

--- a/lib/psabpf_pre.c
+++ b/lib/psabpf_pre.c
@@ -135,8 +135,8 @@ static int do_create_pre_session(psabpf_bpf_map_descriptor_t *pr_map,
             .max_entries = session_template->max_entries,
             .map_type = session_template->type,
             .btf_fd = btf->btf_fd,
-            .btf_key_type_id = session_template->key_type_id,
-            .btf_value_type_id = session_template->value_type_id,
+            .btf_key_type_id = session_template->map_key_type_id,
+            .btf_value_type_id = session_template->map_value_type_id,
     };
     int inner_map_fd = bpf_create_map_xattr(&attr);
     if (inner_map_fd < 0) {

--- a/lib/psabpf_register.c
+++ b/lib/psabpf_register.c
@@ -45,14 +45,12 @@ void psabpf_register_ctx_free(psabpf_register_context_t *ctx) {
 
 static int parse_key_type(psabpf_register_context_t *ctx)
 {
-    uint32_t type_id = psabtf_get_member_type_id_by_name(ctx->btf_metadata.btf, ctx->reg.btf_type_id, "key");
-    return parse_struct_type(&ctx->btf_metadata, type_id, ctx->reg.key_size, &ctx->key_fds);
+    return parse_struct_type(&ctx->btf_metadata, ctx->reg.key_type_id, ctx->reg.key_size, &ctx->key_fds);
 }
 
 static int parse_value_type(psabpf_register_context_t *ctx)
 {
-    uint32_t type_id = psabtf_get_member_type_id_by_name(ctx->btf_metadata.btf, ctx->reg.btf_type_id, "value");
-    return parse_struct_type(&ctx->btf_metadata, type_id, ctx->reg.value_size, &ctx->value_fds);
+    return parse_struct_type(&ctx->btf_metadata, ctx->reg.value_type_id, ctx->reg.value_size, &ctx->value_fds);
 }
 
 int psabpf_register_ctx_name(psabpf_context_t *psabpf_ctx, psabpf_register_context_t *ctx, const char *name) {

--- a/lib/psabpf_table.c
+++ b/lib/psabpf_table.c
@@ -90,8 +90,9 @@ void psabpf_table_entry_ctx_free(psabpf_table_entry_ctx_t *ctx)
 
 static int get_value_type(psabpf_table_entry_ctx_t *ctx, const struct btf_type **value_type)
 {
-    if (ctx->table.value_type_id == 0)
+    if (ctx->table.value_type_id == 0) {
         return ENOENT;
+    }
     *value_type = psabtf_get_type_by_id(ctx->btf_metadata.btf, ctx->table.value_type_id);
     if (value_type == NULL)
         return EPERM;
@@ -136,8 +137,9 @@ static bool member_is_direct_or_implementation_object(psabpf_btf_t *btf, const s
 
 static int count_direct_objects(psabpf_table_entry_ctx_t *ctx)
 {
-    if (ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0)
+    if (ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0) {
         return NO_ERROR;
+    }
 
     const struct btf_type *value_type;
     int ret = get_value_type(ctx, &value_type);
@@ -178,14 +180,16 @@ static void try_find_group_mark_for_table_impl(psabpf_table_entry_ctx_t *ctx, un
 {
     char expected_name[256];
     psabtf_struct_member_md_t md;
-    if (ctx->table.value_type_id == 0)
+    if (ctx->table.value_type_id == 0) {
         return;
+    }
 
     snprintf(expected_name, sizeof(expected_name), "%s_is_group_ref",
              ctx->table_implementations.fields[table_impl_id].name);
 
-    if (psabtf_get_member_md_by_name(ctx->btf_metadata.btf, ctx->table.value_type_id, expected_name, &md) != NO_ERROR)
+    if (psabtf_get_member_md_by_name(ctx->btf_metadata.btf, ctx->table.value_type_id, expected_name, &md) != NO_ERROR) {
         return;
+    }
 
     size_t size = psabtf_get_type_size_by_id(ctx->btf_metadata.btf, md.effective_type_id);
     if (size != sizeof(uint32_t))
@@ -199,8 +203,9 @@ static void try_find_group_mark_for_table_impl(psabpf_table_entry_ctx_t *ctx, un
 
 static int init_direct_objects_context(psabpf_table_entry_ctx_t *ctx)
 {
-    if (ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0)
+    if (ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0) {
         return NO_ERROR;
+    }
 
     const struct btf_type *value_type;
     int ret = get_value_type(ctx, &value_type);
@@ -806,8 +811,9 @@ const char *psabpf_action_param_get_name(psabpf_table_entry_ctx_t *ctx, psabpf_t
 {
     if (ctx == NULL || entry == NULL || param == NULL)
         return NULL;
-    if (entry->action == NULL || ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0)
+    if (entry->action == NULL || ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0) {
         return NULL;
+    }
 
     if (ctx->is_indirect) {
         if (param->param_id >= ctx->table_implementations.n_fields)
@@ -819,8 +825,9 @@ const char *psabpf_action_param_get_name(psabpf_table_entry_ctx_t *ctx, psabpf_t
      * only if number of parameter from entry is equal to that number. */
 
     psabtf_struct_member_md_t union_md = {};
-    if (psabtf_get_member_md_by_name(ctx->btf_metadata.btf, ctx->table.value_type_id, "u", &union_md) != NO_ERROR)
+    if (psabtf_get_member_md_by_name(ctx->btf_metadata.btf, ctx->table.value_type_id, "u", &union_md) != NO_ERROR) {
         return NULL;
+    }
 
     psabtf_struct_member_md_t action_md = {};
     if (psabtf_get_member_md_by_index(ctx->btf_metadata.btf, union_md.effective_type_id, entry->action->action_id, &action_md) != NO_ERROR)
@@ -879,12 +886,14 @@ uint32_t psabpf_table_get_action_id_by_name(psabpf_table_entry_ctx_t *ctx, const
 {
     if (ctx == NULL || name == NULL)
         return PSABPF_INVALID_ACTION_ID;
-    if (ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0 || ctx->is_indirect)
+    if (ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0 || ctx->is_indirect) {
         return PSABPF_INVALID_ACTION_ID;
+    }
 
     psabtf_struct_member_md_t union_md = {};
-    if (psabtf_get_member_md_by_name(ctx->btf_metadata.btf, ctx->table.value_type_id, "u", &union_md) != NO_ERROR)
+    if (psabtf_get_member_md_by_name(ctx->btf_metadata.btf, ctx->table.value_type_id, "u", &union_md) != NO_ERROR) {
         return PSABPF_INVALID_ACTION_ID;
+    }
 
     psabtf_struct_member_md_t action_md = {};
     if (psabtf_get_member_md_by_name(ctx->btf_metadata.btf, union_md.effective_type_id, name, &action_md) != NO_ERROR)
@@ -945,12 +954,14 @@ const char *psabpf_action_get_name(psabpf_table_entry_ctx_t *ctx, uint32_t actio
 {
     if (ctx == NULL)
         return NULL;
-    if (ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0)
+    if (ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0) {
         return NULL;
+    }
 
     psabtf_struct_member_md_t union_md = {};
-    if (psabtf_get_member_md_by_name(ctx->btf_metadata.btf, ctx->table.value_type_id, "u", &union_md) != NO_ERROR)
+    if (psabtf_get_member_md_by_name(ctx->btf_metadata.btf, ctx->table.value_type_id, "u", &union_md) != NO_ERROR) {
         return NULL;
+    }
 
     psabtf_struct_member_md_t action_md = {};
     if (psabtf_get_member_md_by_index(ctx->btf_metadata.btf, union_md.effective_type_id, action_id, &action_md) != NO_ERROR)
@@ -1433,8 +1444,9 @@ static int fill_key_mask_byte_by_byte(char * buffer, psabpf_table_entry_ctx_t *c
 static int fill_key_mask_btf(char * buffer, psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry)
 {
     /* Use key type to generate mask */
-    if (ctx->table.key_type_id == 0)
+    if (ctx->table.key_type_id == 0) {
         return EAGAIN;
+    }
 
     const struct btf_type *key_type = psabtf_get_type_by_id(ctx->btf_metadata.btf, ctx->table.key_type_id);
     if (key_type == NULL)
@@ -1585,8 +1597,9 @@ static int handle_direct_meter_write(char *value, psabpf_table_entry_ctx_t *ctx,
 static int handle_direct_objects_write(const char *key, char *value, psabpf_bpf_map_descriptor_t *map,
                                        psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry, uint64_t bpf_flags)
 {
-    if (ctx->is_indirect || ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0)
+    if (ctx->is_indirect || ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0) {
         return NO_ERROR;
+    }
 
     int ret = handle_direct_meter_write(value, ctx, entry);
     if (ret != NO_ERROR)
@@ -2525,8 +2538,9 @@ static int parse_table_value(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t
         return ENOMEM;
     psabpf_action_init(entry->action);
 
-    if (ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0)
+    if (ctx->btf_metadata.btf == NULL || ctx->table.value_type_id == 0) {
         return parse_table_value_no_btf(ctx, entry, value);
+    }
 
     return parse_table_value_btf_info(ctx, entry, value);
 }
@@ -2747,8 +2761,9 @@ static int parse_table_key_btf_info(psabpf_table_entry_ctx_t *ctx, psabpf_table_
 int parse_table_key(psabpf_table_entry_ctx_t *ctx, psabpf_table_entry_t *entry,
                     const void *key, const void *key_mask)
 {
-    if (ctx->btf_metadata.btf == NULL || ctx->table.key_type_id == 0)
+    if (ctx->btf_metadata.btf == NULL || ctx->table.key_type_id == 0) {
         return parse_table_key_no_btf(ctx, entry, key, key_mask);
+    }
 
     return parse_table_key_btf_info(ctx, entry, key, key_mask);
 }

--- a/lib/psabpf_value_set.c
+++ b/lib/psabpf_value_set.c
@@ -55,9 +55,7 @@ void psabpf_value_set_context_free(psabpf_value_set_context_t *ctx) {
 
 static int parse_key_type(psabpf_value_set_context_t *ctx)
 {
-    uint32_t type_id = psabtf_get_member_type_id_by_name(ctx->btf_metadata.btf, ctx->set_map.btf_type_id, "key");
-
-    return parse_struct_type(&ctx->btf_metadata, type_id, ctx->set_map.key_size, &ctx->fds);
+    return parse_struct_type(&ctx->btf_metadata, ctx->set_map.key_type_id, ctx->set_map.key_size, &ctx->fds);
 }
 
 int psabpf_value_set_context_name(psabpf_context_t *psabpf_ctx, psabpf_value_set_context_t *ctx, const char *name) {

--- a/main.c
+++ b/main.c
@@ -69,6 +69,7 @@ static int do_help(int argc, char **argv)
             "                   del-port |\n"
             "                   table |\n"
             "                   action-selector |\n"
+            "                   action-profile |\n"
             "                   meter |\n"
             "                   digest |\n"
             "                   counter |\n"

--- a/main.c
+++ b/main.c
@@ -132,6 +132,11 @@ static int do_action_selector(int argc, char **argv)
     return cmd_select(action_selector_cmds, argc, argv, do_action_selector_help);
 }
 
+static int do_action_profile(int argc, char **argv)
+{
+    return cmd_select(action_profile_cmds, argc, argv, do_action_profile_help);
+}
+
 static int do_digest(int argc, char **argv)
 {
     return cmd_select(digest_cmds, argc, argv, do_digest_help);
@@ -161,6 +166,7 @@ static const struct cmd cmds[] = {
         { "multicast-group", do_multicast },
         { "table",           do_table },
         { "action-selector", do_action_selector },
+        { "action-profile",  do_action_profile },
         { "meter",           do_meter },
         { "digest",          do_digest },
         { "counter",         do_counter },


### PR DESCRIPTION
closes #16 
PTF tests: https://github.com/tatry/p4c/pull/16

Example outputs:
- Add member:
```json
{
    "ingress_ap": {
        "added_member_ref": 1
    }
}
```
- Get all members:
```json
{
    "ingress_ap": {
        "member_refs": {
            "1": {
                "action_id": 1,
                "action_name": "ingress_a1",
                "action_parameters": [
                    {
                        "name": "param",
                        "value": "0x1"
                    }
                ]
            },
            "3": {
                "action_id": 1,
                "action_name": "ingress_a1",
                "action_parameters": [
                    {
                        "name": "param",
                        "value": "0x3"
                    }
                ]
            },
            "2": {
                "action_id": 1,
                "action_name": "ingress_a1",
                "action_parameters": [
                    {
                        "name": "param",
                        "value": "0x2"
                    }
                ]
            },
            "4": {
                "action_id": 1,
                "action_name": "ingress_a1",
                "action_parameters": [
                    {
                        "name": "param",
                        "value": "0x4"
                    }
                ]
            }
        }
    }
}
```

- Get single member:
```json
{
    "ingress_ap": {
        "member_refs": {
            "1": {
                "action_id": 1,
                "action_name": "ingress_a1",
                "action_parameters": [
                    {
                        "name": "param",
                        "value": "0x1"
                    }
                ]
            }
        }
    }
}
```