### PR TITLE
validate-os: remove bpf device field check

### DIFF
--- a/CLI/os_validate.c
+++ b/CLI/os_validate.c
@@ -104,7 +104,7 @@ static int decode_mounts(struct os_configuration *conf)
         char buf[BUFSIZ];
         while (fgets(buf, BUFSIZ, mounts) != NULL) {
             char *str = &buf[0];
-            strsep(&str, " "); //skip device
+            strsep(&str, " "); /* skip device */
             char *mount_point = strsep(&str, " ");
             char *fs_type = strsep(&str, " ");
             char *options = strsep(&str, " ");

--- a/CLI/os_validate.c
+++ b/CLI/os_validate.c
@@ -104,12 +104,12 @@ static int decode_mounts(struct os_configuration *conf)
         char buf[BUFSIZ];
         while (fgets(buf, BUFSIZ, mounts) != NULL) {
             char *str = &buf[0];
-            char *device = strsep(&str, " ");
+            strsep(&str, " "); //skip device
             char *mount_point = strsep(&str, " ");
             char *fs_type = strsep(&str, " ");
             char *options = strsep(&str, " ");
 
-            if (strcmp(device, "bpf") == 0 && strcmp(fs_type, "bpf") == 0) {
+            if (strcmp(fs_type, "bpf") == 0) {
                 strncpy(&conf->bpf_mount_path[0], mount_point, MAX_STR_LEN);
                 conf->bpf_mount_path[MAX_STR_LEN - 1] = 0;
 


### PR DESCRIPTION
I use NIKSS on a Hyper-V VM running Ubuntu 20.04 (kernel: 5.8). With this setup, BPF is mounted on device "none":

```
$ mount | grep bpf
none on /sys/fs/bpf type bpf (rw,nosuid,nodev,noexec,relatime,mode=700)
```

`nikss-ctl validate-os` interpreted this as BPF not being mounted:

```
$ nikss-ctl validate-os
Kernel family: Linux ... OK
Kernel version: 5.8 ... OK
Machine architecture: x86_64 ... OK
BPF filesystem is mounted: false ... ERROR (BPF filesystem is not mounted)
BPF filesystem mount point:  ... ERROR (expected BPF filesystem to be mounted on /sys/fs/bpf)
BPF filesystem in read-write mode: false ... ERROR (BPF filesystem is not mounted in read-write mode)
Kernel build option CONFIG_BPF: yes ... OK
[...]
Invalid system configuration, NIKSS will not work.
```

This PR fixes that issue by removing the check that requires the mounted device to be named `bpf`.

Credit goes to @mikroskeem for discovering why validate-os was rejecting my system.